### PR TITLE
Updates fastly key header per Fastly documentation.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ Fastly.prototype.request = function (method, url, params, callback) {
     }
 
     // Construct headers
-    var headers = { 'x-fastly-key': self.apikey };
+    var headers = { 'fastly-key': self.apikey };
 
     // HTTP request
     request({


### PR DESCRIPTION
The Fastly documentation says the header should be `fastly-key` instead of `x-fastly-key`. http://docs.fastly.com/api/
