### PR TITLE
Adding accepts header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,10 @@ Fastly.prototype.request = function (method, url, params, callback) {
     }
 
     // Construct headers
-    var headers = { 'fastly-key': self.apikey };
+    var headers = {
+        'fastly-key': self.apikey,
+        'accept': 'application/json'
+    };
 
     // HTTP request
     request({


### PR DESCRIPTION
This is as per Fastly's API documentation
