### PR TITLE
Fastly has updated their documentation and the older URL's now 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,27 +31,27 @@ The fastly module also includes a few limited "helper" methods that make working
     <tr>
         <td>purge</td>
         <td><pre lang="javascript"><code>fastly.purge('host.com', '/index.html', callback);</code></pre></td>
-        <td><a href="https://www.fastly.com/docs/api/purge">Link</a></td>
+        <td><a href="https://docs.fastly.com/api/purge">Link</a></td>
     </tr>
     <tr>
         <td>purgeAll</td>
         <td><pre lang="javascript"><code>fastly.purgeAll('myServiceId', callback);</code></pre></td>
-        <td><a href="https://www.fastly.com/docs/api/purge">Link</a></td>
+        <td><a href="https://docs.fastly.com/api/purge">Link</a></td>
     </tr>
     <tr>
         <td>purgeKey</td>
         <td><pre lang="javascript"><code>fastly.purgeKey('myServiceId', 'key', callback);</code></pre></td>
-        <td><a href="https://www.fastly.com/docs/api/purge">Link</a></td>
+        <td><a href="https://docs.fastly.com/api/purge">Link</a></td>
     </tr>
     <tr>
         <td>softPurgeKey</td>
         <td><pre lang="javascript"><code>fastly.softPurgeKey('myServiceId', 'key', callback);</code></pre></td>
-        <td><a href="https://www.fastly.com/docs/api/purge">Link</a></td>
+        <td><a href="https://docs.fastly.com/api/purge">Link</a></td>
     </tr>
     <tr>
         <td>stats</td>
         <td><pre lang="javascript"><code>fastly.stats('myServiceId', callback);</code></pre></td>
-        <td><a href="https://www.fastly.com/docs/api/stats">Link</a></td>
+        <td><a href="https://docs.fastly.com/api/stats">Link</a></td>
     </tr>
     <tr>
         <td>datacenters</td>


### PR DESCRIPTION
This should fix the documentation links to point to the new docs in fastly