### PR TITLE
Fix response's `content-type` checking

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ Fastly.prototype.request = function (method, url, params, callback) {
             if (err) err.statusCode = statusCode;
         }
         if (err) return callback(err);
-        if (response.headers['content-type'] === 'application/json') {
+        if (response.headers['content-type'].indexOf('application/json') === 0) {
             try {
                 body = JSON.parse(body);
             } catch (er) {


### PR DESCRIPTION
Fastly's added `charset=utf-8` to their `content-type` response header,
which breaks current parsing.